### PR TITLE
[Backport/Fix] Uploaded images in newsletter

### DIFF
--- a/config/i18n-tasks.yml
+++ b/config/i18n-tasks.yml
@@ -92,6 +92,9 @@ ignore_missing:
  - layouts.decidim.header.user_menu
  - decidim.devise.shared.omniauth_buttons.or
  - devise.shared.links.sign_in_with_provider
+ - decidim.editor_images.create.error
+ - decidim.editor_images.create.success
+
 # Consider these keys used:
 ignore_unused:
   - faker.*

--- a/config/initializers/extends.rb
+++ b/config/initializers/extends.rb
@@ -2,3 +2,4 @@
 
 require "extends/controllers/decidim/devise/sessions_controller_extends"
 require "extends/queries/decidim/participatory_processes/group_participatory_processes_extends"
+require "extends/controllers/decidim/editor_images_controller_extends"

--- a/lib/extends/controllers/decidim/editor_images_controller_extends.rb
+++ b/lib/extends/controllers/decidim/editor_images_controller_extends.rb
@@ -1,0 +1,23 @@
+# frozen_string_literal: true
+
+module EditorImagesExtends
+  def create
+    enforce_permission_to :create, :editor_image
+
+    @form = form(Decidim::EditorImageForm).from_params(form_values)
+
+    Decidim::CreateEditorImage.call(@form) do
+      on(:ok) do |image|
+        render json: { url: image.attached_uploader(:file).url(host: current_organization.host), message: I18n.t("success", scope: "decidim.editor_images.create") }
+      end
+
+      on(:invalid) do |_message|
+        render json: { message: I18n.t("error", scope: "decidim.editor_images.create") }, status: :unprocessable_entity
+      end
+    end
+  end
+end
+
+Decidim::EditorImagesController.class_eval do
+  prepend(EditorImagesExtends)
+end

--- a/spec/controllers/editor_images_controller_spec.rb
+++ b/spec/controllers/editor_images_controller_spec.rb
@@ -1,0 +1,92 @@
+# frozen_string_literal: true
+
+require "spec_helper"
+
+module Decidim
+  describe EditorImagesController, type: :controller do
+    routes { Decidim::Core::Engine.routes }
+
+    let(:organization) { create(:organization) }
+    let(:editor_images_path) { Rails.application.routes.url_helpers.editor_images_url(organization.open_data_file.blob, only_path: true) }
+    let(:user) { create(:user, :confirmed, organization: organization) }
+    let(:admin) { create(:user, :confirmed, :admin, organization: organization) }
+    let(:image) do
+      Rack::Test::UploadedFile.new(
+        Decidim::Dev.test_file("city.jpeg", "image/jpeg"),
+        "image/jpeg"
+      )
+    end
+    let(:invalid_image) do
+      Rack::Test::UploadedFile.new(
+        Decidim::Dev.test_file("invalid.jpeg", "image/jpeg"),
+        "image/jpeg"
+      )
+    end
+    let(:valid_params) { { image: image } }
+    let(:invalid_params) { { image: invalid_image } }
+
+    before do
+      request.env["decidim.current_organization"] = organization
+    end
+
+    describe "POST create" do
+      context "when no user is signed in" do
+        it "doesn't create an editor image" do
+          expect do
+            post :create, params: valid_params
+          end.not_to(change { Decidim::EditorImage.count })
+
+          expect(response).to have_http_status(:redirect)
+        end
+      end
+
+      context "when user has no admin permissions" do
+        before do
+          sign_in user
+        end
+
+        it "doesn't create an editor image" do
+          expect do
+            post :create, params: valid_params
+          end.not_to(change { Decidim::EditorImage.count })
+
+          expect(response).to have_http_status(:redirect)
+        end
+      end
+
+      context "when admin is signed in" do
+        before do
+          sign_in admin
+        end
+
+        it "creates an editor image" do
+          expect do
+            post :create, params: valid_params
+          end.to change { Decidim::EditorImage.count }.by(1)
+
+          expect(response).to have_http_status(:ok)
+        end
+
+        it "returns full image url" do
+          expect do
+            post :create, params: valid_params
+          end.to change { Decidim::EditorImage.count }.by(1)
+
+          active_storage_path = Decidim::EditorImage.first.attached_uploader(:file).path
+          expect(response.body).to eq({ url: "http://#{organization.host}#{active_storage_path}", message: "Image uploaded successfully" }.to_json)
+        end
+
+        context "when file is not valid" do
+          it "doesn't create an editor image and returns an error message" do
+            expect do
+              post :create, params: invalid_params
+            end.not_to(change { Decidim::EditorImage.count })
+
+            expect(response).to have_http_status(:unprocessable_entity)
+            expect(response.body).to include("Error uploading image")
+          end
+        end
+      end
+    end
+  end
+end


### PR DESCRIPTION
🎩 Description
Please describe your pull request.

When admin uploaded an image in newsletter body, AJAX response only contained a relative path of the URL. When user opens the newsletter in a mailer, image is missing because the path was incorrect.

📌 Related Issues
Link your PR to an issue

[Notion card](https://www.notion.so/opensourcepolitics/MEL-Backport-fix-newsletters-3c98d0d1896b497083162b7acf0015e7)

Testing
Describe the best way to test or validate your PR.

Create newsletter
Import image using editor
Send newsletter
In letter_opener, you should see the image, AND url must include current host ex: http://localhost:3000/rails/....

NOTE: In local image can be missing since the added host isn't localhost:3000 but localhost