### PR TITLE
Bump decidim friendly_signup from 0.4.2 to 0.4.4

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -19,7 +19,7 @@ gem "omniauth-france_connect", git: "https://github.com/OpenSourcePolitics/omnia
 gem "omniauth-publik", git: "https://github.com/OpenSourcePolitics/omniauth-publik"
 
 gem "decidim-decidim_awesome", "0.8.3"
-gem "decidim-friendly_signup"
+gem "decidim-friendly_signup", "0.4.4"
 
 gem "dotenv-rails"
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -376,7 +376,7 @@ GEM
       decidim-admin (>= 0.25.0, < 0.27)
       decidim-core (>= 0.25.0, < 0.27)
       sassc (~> 2.3)
-    decidim-friendly_signup (0.4.2)
+    decidim-friendly_signup (0.4.4)
       decidim-core (~> 0.26.0)
     decidim-templates (0.26.2)
       decidim-core (= 0.26.2)
@@ -933,7 +933,7 @@ DEPENDENCIES
   decidim!
   decidim-decidim_awesome (= 0.8.3)
   decidim-dev!
-  decidim-friendly_signup
+  decidim-friendly_signup (= 0.4.4)
   decidim-phone_authorization_handler!
   decidim-spam_detection!
   decidim-templates


### PR DESCRIPTION
#### Description

Bump friendly signup from `0.4.2` to `0.4.4` 

Fix missing host in confirmation email