### PR TITLE
[Fix] - Header and footer links in the newsletter

### DIFF
--- a/app/cells/decidim/newsletter_templates/mel_template/show.erb
+++ b/app/cells/decidim/newsletter_templates/mel_template/show.erb
@@ -5,7 +5,7 @@
         <tr>
           <th class="decidim-bar" >
             <center>
-              <%= image_pack_tag("media/images/header_email.png", alt: t("alt_banner_image", scope: "decidim.newsletter_templates.mel_template")) %>
+              <img src="<%= "#{Rails.application.config.action_mailer.asset_host}#{asset_pack_path('media/images/header_email.png')}" %>" alt="<%= t('alt_banner_image', scope: 'decidim.newsletter_templates.mel_template') %>">
             </center>
           </th>
         </tr>
@@ -46,7 +46,7 @@
         <tr>
           <th class="expander"></th>
           <th class="cityhall-bar show-for-large">
-            <%= image_pack_tag("media/images/footer_email_group.png", alt: t("alt_banner_image", scope: "decidim.newsletter_templates.mel_template")) %>
+            <img src="<%= "#{Rails.application.config.action_mailer.asset_host}#{asset_pack_path('media/images/footer_email_group.png')}" %>" alt="<%= t('alt_banner_image', scope: 'decidim.newsletter_templates.mel_template') %>">
           </th>
           <th class="footer-menu">
             <div class="footer-menu-item">

--- a/app/cells/decidim/newsletter_templates/mel_template/show.erb
+++ b/app/cells/decidim/newsletter_templates/mel_template/show.erb
@@ -5,7 +5,7 @@
         <tr>
           <th class="decidim-bar" >
             <center>
-              <img src="<%= "#{Rails.application.config.action_mailer.asset_host}#{asset_pack_path('media/images/header_email.png')}" %>" alt="<%= t('alt_banner_image', scope: 'decidim.newsletter_templates.mel_template') %>">
+              <%= image_tag(organization_asset_url("media/images/header_email.png"), alt: t("alt_banner_image", scope: "decidim.newsletter_templates.mel_template")) %>
             </center>
           </th>
         </tr>
@@ -46,7 +46,7 @@
         <tr>
           <th class="expander"></th>
           <th class="cityhall-bar show-for-large">
-            <img src="<%= "#{Rails.application.config.action_mailer.asset_host}#{asset_pack_path('media/images/footer_email_group.png')}" %>" alt="<%= t('alt_banner_image', scope: 'decidim.newsletter_templates.mel_template') %>">
+            <%= image_tag(organization_asset_url("media/images/footer_email_group.png"), alt: t("alt_banner_image", scope: "decidim.newsletter_templates.mel_template")) %>
           </th>
           <th class="footer-menu">
             <div class="footer-menu-item">

--- a/app/cells/decidim/newsletter_templates/mel_template_cell.rb
+++ b/app/cells/decidim/newsletter_templates/mel_template_cell.rb
@@ -30,7 +30,7 @@ module Decidim
       def organization_host
         port = Rails.env.development? ? 3000 : nil
 
-        "#{decidim.root_url(host: current_organization.host, port: port)}".gsub(/\/$/, "")
+        decidim.root_url(host: current_organization.host, port: port).to_s.gsub(%r{/$}, "")
       end
     end
   end

--- a/app/cells/decidim/newsletter_templates/mel_template_cell.rb
+++ b/app/cells/decidim/newsletter_templates/mel_template_cell.rb
@@ -22,15 +22,15 @@ module Decidim
       end
 
       def organization_asset_url(asset)
-        "#{organization_host}#{image_pack_url(asset)}"
+        "#{organization_host}#{asset_pack_url(asset)}"
       end
 
       private
 
       def organization_host
-        return "https://#{current_organization.host}/" unless Rails.env.development?
+        port = Rails.env.development? ? 3000 : nil
 
-        "http://#{current_organization.host}:3000"
+        "#{decidim.root_url(host: current_organization.host, port: port)}".gsub(/\/$/, "")
       end
     end
   end

--- a/app/cells/decidim/newsletter_templates/mel_template_cell.rb
+++ b/app/cells/decidim/newsletter_templates/mel_template_cell.rb
@@ -22,15 +22,22 @@ module Decidim
       end
 
       def organization_asset_url(asset)
-        "#{organization_host}#{asset_pack_url(asset)}"
+        asset_pack_url(asset, host: organization_root_url)
       end
 
       private
 
-      def organization_host
-        port = Rails.env.development? ? 3000 : nil
+      def organization_root_url
+        @organization_root_url ||= decidim.root_url(host: organization_host)
+      end
 
-        decidim.root_url(host: current_organization.host, port: port).to_s.gsub(%r{/$}, "")
+      def organization_host
+        port = 3000
+        @organization_host = if Rails.env.development?
+                               "#{current_organization.host}:#{port}"
+                             else
+                               current_organization.host
+                             end
       end
     end
   end

--- a/app/cells/decidim/newsletter_templates/mel_template_cell.rb
+++ b/app/cells/decidim/newsletter_templates/mel_template_cell.rb
@@ -20,6 +20,18 @@ module Decidim
       def email_footer_css
         "decidim/email"
       end
+
+      def organization_asset_url(asset)
+        "#{organization_host}#{image_pack_url(asset)}"
+      end
+
+      private
+
+      def organization_host
+        return "https://#{current_organization.host}/" unless Rails.env.development?
+
+        "http://#{current_organization.host}:3000"
+      end
     end
   end
 end

--- a/app/cells/decidim/newsletter_templates/mel_template_cell.rb
+++ b/app/cells/decidim/newsletter_templates/mel_template_cell.rb
@@ -33,11 +33,11 @@ module Decidim
 
       def organization_host
         port = 3000
-        @organization_host = if Rails.env.development?
-                               "#{current_organization.host}:#{port}"
-                             else
-                               current_organization.host
-                             end
+        @organization_host ||= if Rails.env.development?
+                                 "#{current_organization.host}:#{port}"
+                               else
+                                 current_organization.host
+                               end
       end
     end
   end

--- a/config/application.rb
+++ b/config/application.rb
@@ -24,7 +24,7 @@ module DevelopmentApp
 
     # This needs to be set for correct images URLs in emails
     # DON'T FORGET to ALSO set this in `config/initializers/carrierwave.rb`
-    config.action_mailer.asset_host = "https://#{Rails.application.secrets[:asset_host]}" if Rails.application.secrets[:asset_host].present?
+    config.action_mailer.asset_host = "https://#{Rails.application.secrets[:asset_host]}/" if Rails.application.secrets[:asset_host].present?
 
     config.backup = config_for(:backup).deep_symbolize_keys
 

--- a/config/application.rb
+++ b/config/application.rb
@@ -24,7 +24,7 @@ module DevelopmentApp
 
     # This needs to be set for correct images URLs in emails
     # DON'T FORGET to ALSO set this in `config/initializers/carrierwave.rb`
-    config.action_mailer.asset_host = "https://#{Rails.application.secrets[:asset_host]}/" if Rails.application.secrets[:asset_host].present?
+    config.action_mailer.asset_host = "https://#{Rails.application.secrets[:asset_host]}" if Rails.application.secrets[:asset_host].present?
 
     config.backup = config_for(:backup).deep_symbolize_keys
 


### PR DESCRIPTION
### Description 

Base images (like header and footer) were not displayed on emails because we had a relative link so when we were asking for /decidim-packs/header in a gmail mail in reality we were asking gmail/decidim-packs/header that obviously does not exist.

#### Tasks

- [x] Change the way we displayed header and footer in template
- [x] Update the Application.rb to just get rid of the final slash to avoid duplications in the url


#### How to test

- First of all you'll need to add to you environment your host (ex: localhost:3000)
- You'll need to check if your protocol is http or https, in the first case you'll need to change the line 27 in your application.rb to get rid of the "s"
- Initialize your app
- Go to newsletters
- Create a new one using the first pattern
- Use your browser console to check if the src of the image is complete (If your url starts with a / that means it doesn't work because you have a relative path.)